### PR TITLE
Remove default config value

### DIFF
--- a/site/plugins/autopublish/autopublish.php
+++ b/site/plugins/autopublish/autopublish.php
@@ -3,7 +3,7 @@
 kirby()->hook('panel.page.create', 'run');
 
 function run( $page ) {
-	$templates = c::get('autopublish.templates', array('project', 'item'));
+	$templates = c::get('autopublish.templates');
 	if (!$templates || in_array($page->template(), $templates)) {
 		try {
 			$page->toggle('last');


### PR DESCRIPTION
With the default config value the auto publish for all pages will not work.
