### PR TITLE
Update autopublish.php

### DIFF
--- a/site/plugins/autopublish/autopublish.php
+++ b/site/plugins/autopublish/autopublish.php
@@ -4,7 +4,7 @@ kirby()->hook('panel.page.create', 'run');
 
 function run( $page ) {
 	$templates = c::get('autopublish.templates');
-	if (!$templates || in_array($page->template(), $templates)) {
+	if (!$templates || in_array($page->intendedTemplate(), $templates)) {
 		try {
 			$page->toggle('last');
 		} catch(Exception $e) {


### PR DESCRIPTION
Sometimes there are reasons why one could define a specific blueprint that has no other template than default. Could be because of permissions (Kirby 2.4+) based on a template. Autopublish doesn't work for these use cases as $page->template() returns "default" if the corresponding template doesn't exist. Changing $page->template() to $page->intendedTemplate() solves this problem.
