### PR TITLE
Update autopublish.php

### DIFF
--- a/site/plugins/autopublish/autopublish.php
+++ b/site/plugins/autopublish/autopublish.php
@@ -1,8 +1,6 @@
 <?php
 
-kirby()->hook('panel.page.create', 'run');
-
-function run( $page ) {
+kirby()->hook('panel.page.create', function($page) {
 	$templates = c::get('autopublish.templates');
 	if (!$templates || in_array($page->template(), $templates)) {
 		try {
@@ -11,4 +9,4 @@ function run( $page ) {
 			return response::error($e->getMessage());
 		}
 	}
-}
+});


### PR DESCRIPTION
With Kirby 2.4 the old version with the separate "run" functions doesn't work anymore (perhaps there is a different way to use separate functions), so one has to give it the function directly as callback.